### PR TITLE
chore: add desktop.ini to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .jupyter/
 .ipynb_checkpoints/
+desktop.ini
 
 # Certificate of Registration is sensitive
 Imperial_CSIS311_Library_Book,Rcpt,COR.docx


### PR DESCRIPTION
The desktop.ini file is a system file used by Windows to store folder view settings and customizations. Adding desktop.ini to the .gitignore file prevents it from being tracked by Git, which is beneficial for the following reasons:

1. **Irrelevance to the Project**: The desktop.ini file is not relevant to the source code or project files. It does not contribute to the functionality or development of the project.

2. **Avoiding Unnecessary Changes**: Since desktop.ini can change frequently based on user-specific folder settings, tracking it can lead to unnecessary commits and clutter in the version history.

3. **Cross-Platform Compatibility**: The desktop.ini file is specific to Windows. Ignoring it ensures that non-Windows users do not encounter irrelevant files in the repository.

By ignoring desktop.ini, you keep the repository clean and focused on the files that matter for the project.